### PR TITLE
ci: restrict GITHUB_TOKEN permissions to contents:read

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -1,5 +1,7 @@
 name: Build and Lint
 on: push
+permissions:
+  contents: read
 concurrency:
   group: '${{ github.workflow }}-${{ github.ref }}'
   cancel-in-progress: true


### PR DESCRIPTION
## Summary
- Adds `permissions: {contents: read}` to `.github/workflows/build-test.yml`
- Neither the `build` nor `test` job writes to the repo, PRs, or packages (checkout, npm install, build, test only), so the default unrestricted `GITHUB_TOKEN` scope was broader than needed

## Test plan
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)